### PR TITLE
considering simulator device name

### DIFF
--- a/native/ios/com_diamonddevgroup_device_DeviceNativeImpl.m
+++ b/native/ios/com_diamonddevgroup_device_DeviceNativeImpl.m
@@ -184,9 +184,9 @@ NSString * const x86_64_Sim = @"x86_64";
 
     NSDictionary* deviceList = [self getDeviceList];
     NSString* model = [[deviceList objectForKey : hardware] objectForKey : @"name"];
-
+    
     if (model) {
-        return model;
+        return ([model isEqualToString:@"Simulator"])? [NSProcessInfo processInfo].environment[@"SIMULATOR_DEVICE_NAME"] : model;
     } else {
         return @"Unknown";
     }


### PR DESCRIPTION
something really needed when it comes to simulations where the simulated device has a home bar (like on iPhone X etc) as the app layout has to be adapted in those cases programmatically.